### PR TITLE
docs: add detailed project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # PentestAIAgent
+
+PentestAIAgent is a FastAPI service that exposes an AI-assisted penetration testing agent.  
+The agent uses Anthropic's Claude model via LangGraph and orchestrates a collection of
+local-only security tools.  A simple HTTP API lets you issue natural language
+commands and receive pentest results.
+
+## Features
+- ReAct-style agent that invokes multiple security scanners.
+- Tools provided out of the box:
+  - `nmap_scan` – safe wrapper around `nmap` with allow-list controls
+  - `http_fingerprint` – fetch HTTP headers and a title snippet
+  - `dirbuster` – brute-force common directories and files
+  - `xss_probe` – send payloads to detect reflected XSS
+  - `sqli_probe` – try classic SQL injection strings
+  - `headers_audit` – check missing security headers and cookie flags
+  - `debug_finder` – search for debug/admin endpoints
+  - `crawl_site` – lightweight crawler and form enumerator
+  - `cors_audit` – inspect CORS responses and preflights
+  - `methods_fuzzer` – probe enabled HTTP verbs
+- All tools default to localhost targets for safety and require explicit
+  configuration to scan remote hosts.
+
+## Project Layout
+```
+.
+├── app
+│   ├── main.py          # FastAPI application and agent wiring
+│   └── tools/           # Individual scanning utilities
+├── requirements.txt     # Python dependencies
+├── LICENSE
+└── README.md
+```
+
+## Installation
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+# Extra runtime dependencies used by tools
+pip install requests beautifulsoup4 python-dotenv
+```
+Ensure the `nmap` binary is installed and on your PATH if you plan to use the
+`nmap_scan` tool.
+
+## Configuration
+Set environment variables before running the service:
+- `ANTHROPIC_API_KEY` – API key for the Claude model.
+- For remote network scans (disabled by default), set:
+  - `ALLOW_REMOTE_PENTEST=I_ACCEPT_RESPONSIBILITY`
+  - `PENTEST_ALLOWLIST` with comma-separated hostnames/IPs
+  - optionally `NMAP_PATH` to specify a custom `nmap` binary.
+
+## Running
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+- `GET /` returns a simple health message.
+- `POST /chat` with JSON `{ "message": "run headers_audit on http://127.0.0.1:3000" }`
+  lets the agent execute tools and respond with results.
+
+## License
+This project is licensed under the terms of the MIT license.  See the `LICENSE`
+file for details.


### PR DESCRIPTION
## Summary
- Document FastAPI pentest agent and included security tools
- Add setup, configuration, and usage instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfe329f14832cbf9a912d1501c284