### PR TITLE
test: add unit tests for tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # PentestAIAgent
+
+PentestAIAgent is a FastAPI service that exposes an AI-assisted penetration testing agent.  
+The agent uses Anthropic's Claude model via LangGraph and orchestrates a collection of
+local-only security tools.  A simple HTTP API lets you issue natural language
+commands and receive pentest results.
+
+## Features
+- ReAct-style agent that invokes multiple security scanners.
+- Tools provided out of the box:
+  - `nmap_scan` – safe wrapper around `nmap` with allow-list controls
+  - `http_fingerprint` – fetch HTTP headers and a title snippet
+  - `dirbuster` – brute-force common directories and files
+  - `xss_probe` – send payloads to detect reflected XSS
+  - `sqli_probe` – try classic SQL injection strings
+  - `headers_audit` – check missing security headers and cookie flags
+  - `debug_finder` – search for debug/admin endpoints
+  - `crawl_site` – lightweight crawler and form enumerator
+  - `cors_audit` – inspect CORS responses and preflights
+  - `methods_fuzzer` – probe enabled HTTP verbs
+- All tools default to localhost targets for safety and require explicit
+  configuration to scan remote hosts.
+
+## Project Layout
+```
+.
+├── app
+│   ├── main.py          # FastAPI application and agent wiring
+│   └── tools/           # Individual scanning utilities
+├── requirements.txt     # Python dependencies
+├── LICENSE
+└── README.md
+```
+
+## Installation
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+# Extra runtime dependencies used by tools
+pip install requests beautifulsoup4 python-dotenv
+```
+Ensure the `nmap` binary is installed and on your PATH if you plan to use the
+`nmap_scan` tool.
+
+## Configuration
+Set environment variables before running the service:
+- `ANTHROPIC_API_KEY` – API key for the Claude model.
+- For remote network scans (disabled by default), set:
+  - `ALLOW_REMOTE_PENTEST=I_ACCEPT_RESPONSIBILITY`
+  - `PENTEST_ALLOWLIST` with comma-separated hostnames/IPs
+  - optionally `NMAP_PATH` to specify a custom `nmap` binary.
+
+## Running
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+- `GET /` returns a simple health message.
+- `POST /chat` with JSON `{ "message": "run headers_audit on http://127.0.0.1:3000" }`
+  lets the agent execute tools and respond with results.
+
+## License
+This project is licensed under the terms of the MIT license.  See the `LICENSE`
+file for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ starlette==0.47.3
 typing-extensions==4.15.0
 typing-inspection==0.4.1
 uvicorn==0.35.0
+requests==2.32.3
+beautifulsoup4==4.12.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,110 @@
+import threading, json
+from http.server import BaseHTTPRequestHandler
+import socketserver
+import urllib.parse as up
+
+class TestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = up.urlparse(self.path)
+        path = parsed.path
+        if path == '/search':
+            q = up.parse_qs(parsed.query).get('q', [''])[0]
+            body = f"<html><head><title>Search</title></head><body>{q}</body></html>"
+            self.send_response(200)
+            self.send_header('Content-Type','text/html')
+            if self.headers.get('Origin'):
+                self.send_header('Access-Control-Allow-Origin','*')
+                self.send_header('Access-Control-Allow-Credentials','true')
+                self.send_header('Vary','Origin')
+            self.end_headers()
+            self.wfile.write(body.encode())
+            return
+        if path in ('/admin', '/admin/login', '/swagger'):
+            self.send_response(200)
+            self.send_header('Content-Type','text/html')
+            self.end_headers()
+            self.wfile.write(b'ok')
+            return
+        if path == '/page2':
+            body = '<html><body><a href="/">home</a></body></html>'
+            self.send_response(200)
+            self.send_header('Content-Type','text/html')
+            self.end_headers()
+            self.wfile.write(body.encode())
+            return
+        body = ('<html><head><title>Home</title></head>'
+                '<body><a href="/page2">page2</a>'
+                '<form method="post" action="/rest/user/login">'
+                '<input name="email"/><input name="password" type="password"/></form>'
+                '</body></html>')
+        self.send_response(200)
+        if self.headers.get('Origin'):
+            self.send_header('Access-Control-Allow-Origin','*')
+            self.send_header('Access-Control-Allow-Credentials','true')
+            self.send_header('Vary','Origin')
+        self.send_header('Content-Type','text/html')
+        self.send_header('Set-Cookie','sessionid=1')
+        self.end_headers()
+        self.wfile.write(body.encode())
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length',0))
+        body = self.rfile.read(length).decode()
+        if self.path == '/rest/user/login':
+            try:
+                data = json.loads(body) if body and body.startswith('{') else {k:v[0] for k,v in up.parse_qs(body).items()}
+            except Exception:
+                data = {}
+            user = data.get('email')
+            if user and "'" in user:
+                self.send_response(500)
+                self.send_header('Content-Type','text/plain')
+                self.end_headers()
+                self.wfile.write(b'sql syntax error')
+            elif user == 'admin':
+                self.send_response(200)
+                self.send_header('Content-Type','application/json')
+                self.end_headers()
+                self.wfile.write(b'{"token":"abc"}')
+            else:
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(b'no')
+            return
+        self.send_response(200)
+        self.end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin','*')
+        self.send_header('Access-Control-Allow-Credentials','true')
+        self.send_header('Access-Control-Allow-Methods','GET,POST,PUT,DELETE,PATCH')
+        self.send_header('Access-Control-Allow-Headers','content-type,x-custom')
+        self.end_headers()
+
+    def do_PUT(self):
+        self.send_response(405); self.end_headers()
+    def do_DELETE(self):
+        self.send_response(405); self.end_headers()
+    def do_PATCH(self):
+        self.send_response(405); self.end_headers()
+    def do_HEAD(self):
+        self.send_response(200); self.end_headers()
+    def log_message(self, *args, **kwargs):
+        return
+
+class ThreadedTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+import pytest
+
+@pytest.fixture(scope='session')
+def http_server():
+    server = ThreadedTCPServer(('127.0.0.1', 0), TestHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f'http://127.0.0.1:{port}'
+    yield base_url
+    server.shutdown()
+    thread.join()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+# ensure app module importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.tools.http_fingerprint import http_fingerprint
+from app.tools.dirbuster import dirbuster
+from app.tools.headers_audit import headers_audit
+from app.tools.debug_finder import debug_finder
+from app.tools.cors_audit import cors_audit
+from app.tools.methods_fuzzer import methods_fuzzer
+from app.tools.crawler import crawl_site
+from app.tools.sqli_probe import sqli_probe
+from app.tools.xss_probe import xss_probe
+from app.tools.nmap_tool import nmap_scan
+
+
+def test_http_fingerprint_success(http_server):
+    res = http_fingerprint(f"{http_server}/")
+    assert res["status"] == 200
+    assert res["title"] == "Home"
+
+
+def test_dirbuster_hits_admin(http_server):
+    res = dirbuster(base_url=f"{http_server}/")
+    assert any(h["path"] == "admin" for h in res["hits"])
+
+
+def test_headers_audit_missing_csp(http_server):
+    res = headers_audit(base_url=http_server, path="/")
+    assert "content-security-policy" in res["missing_headers"].lower()
+
+
+def test_debug_finder_detects_admin(http_server):
+    res = debug_finder(base_url=f"{http_server}/")
+    assert any(h["path"] == "admin" for h in res["hits"])
+
+
+def test_cors_audit_flags_risk(http_server):
+    res = cors_audit(base_url=http_server)
+    assert res["risky_patterns"] != ["none"]
+
+
+def test_methods_fuzzer_post_flagged(http_server):
+    res = methods_fuzzer(base_url=http_server, paths=["/"])
+    item = res["results"][0]
+    assert "POST" in item["dangerous_like"]
+
+
+def test_crawler_discovers_page_and_form(http_server):
+    res = crawl_site(start_url=f"{http_server}/", max_pages=5, max_depth=1)
+    assert any(url.endswith("/page2") for url in res["visited"])
+    assert any(f["action"].endswith("/rest/user/login") for f in res["forms"])
+
+
+def test_sqli_probe_detects_error(http_server):
+    res = sqli_probe(base_url=http_server, method="POST_JSON", path="/rest/user/login", payloads=["'"])
+    assert res["any_error_signals"] == "true"
+
+
+def test_xss_probe_detects_reflection(http_server):
+    res = xss_probe(base_url=http_server, method="GET", path="/search", param="q")
+    assert res["reflected"] == "true"
+
+
+def test_nmap_scan_parses_output(monkeypatch):
+    xml = """
+    <nmaprun>
+      <host>
+        <address addr='127.0.0.1'/>
+        <ports>
+          <port portid='80' protocol='tcp'>
+            <state state='open'/>
+            <service name='http' product='Apache' version='2.4'/>
+          </port>
+        </ports>
+      </host>
+    </nmaprun>
+    """
+    def fake_run(args, check, capture_output, text, timeout):
+        return SimpleNamespace(stdout=xml, returncode=0, stderr="")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    res = nmap_scan("127.0.0.1", ports="80")
+    assert res["hosts"][0]["open_ports"][0]["port"] == 80
+
+
+def test_nmap_scan_blocks_remote():
+    with pytest.raises(PermissionError):
+        nmap_scan("8.8.8.8")


### PR DESCRIPTION
## Summary
- Add unit tests exercising HTTP fingerprinting, directory busting, header audit, debug finder, CORS audit, methods fuzzing, crawling, SQLi probe, XSS probe, and nmap parsing
- Update dependencies with requests and BeautifulSoup for test support

## Testing
- `pytest tests/test_tools.py::test_http_fingerprint_success -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68adfe329f14832cbf9a912d1501c284