### PR TITLE
Add CSRF audit tool and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from tools.debug_finder import debug_finder
 from tools.crawler import crawl_site
 from tools.cors_audit import cors_audit
 from tools.methods_fuzzer import methods_fuzzer
+from tools.csrf_audit import csrf_audit
 load_dotenv()
 
 #load anthropic api key
@@ -25,7 +26,7 @@ app = FastAPI()
 
 agent = create_react_agent(
     model="anthropic:claude-3-7-sonnet-latest",  
-    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer],  
+    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, csrf_audit],
     prompt="You are an experienced pentester. Perform a full pentest on the target. You have many tools available, use them to your advantage. When there are findings; Write a professional penetration test report based on provided findings. Structure it with: Executive Summary, Findings Overview, Detailed Technical Findings (with location, severity, description, impact, and proof of concept), Recommendations, and Conclusion. Add remediations if required for each finding. Ensure the writing is clear, concise, and formal, suitable for security professionals."  
 )
 

--- a/app/tools/csrf_audit.py
+++ b/app/tools/csrf_audit.py
@@ -1,0 +1,132 @@
+# tools/csrf_audit.py
+"""
+Simple CSRF audit helper locked to localhost targets.
+
+What it does
+------------
+- Fetches an HTML page and parses forms.
+- Checks whether each form contains an input that looks like a CSRF token.
+- For POST-like forms, submits the form without any token to gauge protection.
+
+Returned data
+-------------
+{
+  "forms": [
+      {
+        "action": "...",      # form action
+        "method": "POST",      # form method
+        "has_token": "true",   # whether a token-like input was found
+        "tokenless_status": "403" # status code from tokenless submission (n/a if not attempted)
+      },
+      ...
+  ],
+  "any_vulnerable": "true" | "false"   # missing token & tokenless request not blocked
+}
+
+Usage
+-----
+from tools.csrf_audit import csrf_audit
+res = csrf_audit(base_url="http://127.0.0.1:3000", path="/")
+print(res)
+"""
+
+from typing import Dict, List
+from urllib.parse import urlparse
+import requests
+from bs4 import BeautifulSoup
+
+LOCAL_NETLOCS = {"127.0.0.1", "localhost", "::1"}
+
+
+def _ensure_localhost(base_url: str) -> None:
+    parsed = urlparse(base_url if base_url.startswith(("http://", "https://")) else "http://" + base_url)
+    host = (parsed.hostname or "").lower()
+    if host not in LOCAL_NETLOCS:
+        raise PermissionError(
+            f"Refused: '{base_url}' is not a localhost target. "
+            "Add explicit allow-lists/consent checks if you intend remote testing."
+        )
+
+
+def _normalize_base(base_url: str) -> str:
+    if not base_url.startswith(("http://", "https://")):
+        base_url = "http://" + base_url
+    return base_url.rstrip("/")
+
+
+def csrf_audit(
+    base_url: str = "http://127.0.0.1:3000",
+    path: str = "/",
+    timeout: int = 8,
+) -> Dict[str, object]:
+    """Audit CSRF tokens on forms at `base_url`+`path`.
+
+    Args:
+      base_url: local base URL (e.g., "http://127.0.0.1:3000")
+      path:     path to fetch (e.g., "/")
+      timeout:  request timeout in seconds
+
+    Returns:
+      Dict summarising forms and whether any appear vulnerable.
+    """
+
+    base_url = _normalize_base(base_url)
+    _ensure_localhost(base_url)
+
+    url = f"{base_url}{path if path.startswith('/') else '/' + path}"
+    session = requests.Session()
+    r = session.get(url, timeout=timeout)
+    soup = BeautifulSoup(r.text, "html.parser")
+
+    forms_out: List[Dict[str, str]] = []
+    any_vuln = False
+
+    for form in soup.find_all("form"):
+        action = form.get("action") or path
+        method = form.get("method", "GET").upper()
+        inputs = form.find_all("input")
+        token_like = any(
+            ("csrf" in (i.get("name", "") + i.get("id", "")).lower() or
+             "token" in (i.get("name", "") + i.get("id", "")).lower())
+            for i in inputs
+        )
+
+        tokenless_status = "n/a"
+        if method in {"POST", "PUT", "PATCH", "DELETE"}:
+            data = {}
+            for inp in inputs:
+                name = inp.get("name")
+                if not name:
+                    continue
+                lname = name.lower()
+                if "csrf" in lname or "token" in lname:
+                    continue
+                data[name] = inp.get("value", "test")
+            target = action if action.startswith("http") else f"{base_url}{action if action.startswith('/') else '/' + action}"
+            try:
+                resp = session.post(target, data=data, timeout=timeout)
+                tokenless_status = str(resp.status_code)
+            except Exception:
+                tokenless_status = "error"
+            if not token_like and tokenless_status != "403":
+                any_vuln = True
+        else:
+            if not token_like:
+                any_vuln = True
+
+        forms_out.append({
+            "action": action,
+            "method": method,
+            "has_token": "true" if token_like else "false",
+            "tokenless_status": tokenless_status,
+        })
+
+    return {"forms": forms_out, "any_vulnerable": "true" if any_vuln else "false"}
+
+
+# Optional CLI
+if __name__ == "__main__":
+    import json, sys
+    p = sys.argv[1] if len(sys.argv) > 1 else "/"
+    res = csrf_audit(path=p)
+    print(json.dumps(res, indent=2))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,6 +18,7 @@ from app.tools.crawler import crawl_site
 from app.tools.sqli_probe import sqli_probe
 from app.tools.xss_probe import xss_probe
 from app.tools.nmap_tool import nmap_scan
+from app.tools.csrf_audit import csrf_audit
 
 
 def test_http_fingerprint_success(http_server):
@@ -92,3 +93,37 @@ def test_nmap_scan_parses_output(monkeypatch):
 def test_nmap_scan_blocks_remote():
     with pytest.raises(PermissionError):
         nmap_scan("8.8.8.8")
+
+
+def test_csrf_audit_flags_missing_token(http_server):
+    res = csrf_audit(base_url=http_server, path="/")
+    assert res["any_vulnerable"] == "true"
+    assert any(f["has_token"] == "false" for f in res["forms"])
+
+
+def test_csrf_audit_detects_token(monkeypatch):
+    html = (
+        '<html><body><form method="post" action="/test">'
+        '<input type="hidden" name="csrf_token" value="abc">'
+        '<input name="user" value="bob"></form></body></html>'
+    )
+
+    class FakeResp:
+        def __init__(self, text, status):
+            self.text = text
+            self.status_code = status
+
+    class FakeSession:
+        def get(self, url, timeout):
+            return FakeResp(html, 200)
+
+        def post(self, url, data=None, timeout=8):
+            return FakeResp("forbidden", 403)
+
+    import requests
+
+    monkeypatch.setattr(requests, "Session", lambda: FakeSession())
+    res = csrf_audit(base_url="http://127.0.0.1", path="/test")
+    assert res["forms"][0]["has_token"] == "true"
+    assert res["forms"][0]["tokenless_status"] == "403"
+    assert res["any_vulnerable"] == "false"


### PR DESCRIPTION
## Summary
- implement `csrf_audit` to detect CSRF protections by scanning forms and sending tokenless submissions
- include CSRF audit in tool registry for agent use
- add tests for forms with and without CSRF tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae02470d68832cacc453da940cfdd0