### PR TITLE
Add JWT audit tool

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from tools.debug_finder import debug_finder
 from tools.crawler import crawl_site
 from tools.cors_audit import cors_audit
 from tools.methods_fuzzer import methods_fuzzer
+from tools.jwt_audit import jwt_audit
 load_dotenv()
 
 #load anthropic api key
@@ -25,7 +26,7 @@ app = FastAPI()
 
 agent = create_react_agent(
     model="anthropic:claude-3-7-sonnet-latest",  
-    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer],  
+    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, jwt_audit],
     prompt="You are an experienced pentester. Perform a full pentest on the target. You have many tools available, use them to your advantage. When there are findings; Write a professional penetration test report based on provided findings. Structure it with: Executive Summary, Findings Overview, Detailed Technical Findings (with location, severity, description, impact, and proof of concept), Recommendations, and Conclusion. Add remediations if required for each finding. Ensure the writing is clear, concise, and formal, suitable for security professionals."  
 )
 

--- a/app/tools/jwt_audit.py
+++ b/app/tools/jwt_audit.py
@@ -1,0 +1,105 @@
+# tools/jwt_audit.py
+"""
+JWT token security audit helper.
+
+What it does
+------------
+- Scans provided headers or body text for JWT tokens.
+- Decodes each token and reports:
+  * insecure algorithms (e.g. ``alg"=="none"")
+  * missing expiration claim ``exp``
+  * weak claims (missing ``iss`` or ``aud``)
+
+Quick usage
+-----------
+from tools.jwt_audit import jwt_audit
+res = jwt_audit(headers={"Authorization": "Bearer <token>"})
+print(res)
+
+Agent usage
+-----------
+Include ``jwt_audit`` in the tools list for ``create_react_agent`` and invoke
+it with relevant headers/body data.
+
+Requirements
+------------
+- Standard library only
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Any
+import base64
+import json
+import re
+
+# Very loose pattern for JWTs (three base64url parts separated by dots)
+JWT_RE = re.compile(r"eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]*")
+
+def _b64decode(segment: str) -> bytes:
+    """Decode a base64url segment, adding padding if required."""
+    padding = '=' * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
+
+def _extract_tokens(headers: Dict[str, str] | None, body: str) -> List[str]:
+    texts: List[str] = []
+    if headers:
+        texts.extend([v for v in headers.values() if isinstance(v, str)])
+    if body:
+        texts.append(body)
+    tokens: List[str] = []
+    for text in texts:
+        tokens.extend(JWT_RE.findall(text))
+    # de-duplicate while preserving order
+    seen = set()
+    uniq = []
+    for tok in tokens:
+        if tok not in seen:
+            seen.add(tok)
+            uniq.append(tok)
+    return uniq
+
+def jwt_audit(headers: Dict[str, str] | None = None, body: str = "") -> Dict[str, Any]:
+    """
+    Analyse JWT tokens in headers or body text.
+
+    Args:
+        headers: optional mapping of HTTP headers.
+        body:    optional request/response body text.
+
+    Returns:
+        dict with a "tokens" list. Each token entry includes:
+        - token: the original token
+        - alg:   algorithm from header
+        - insecure_alg: bool flagging "alg" == "none"
+        - missing_exp:  bool whether ``exp`` claim is absent
+        - weak_claims:  list of missing recommended claims ("iss"/"aud")
+    """
+    results: List[Dict[str, Any]] = []
+    for token in _extract_tokens(headers, body):
+        try:
+            head_b64, payload_b64, _sig = token.split('.')
+            header = json.loads(_b64decode(head_b64))
+            payload = json.loads(_b64decode(payload_b64))
+        except Exception:
+            # skip tokens we fail to decode
+            continue
+        alg = header.get("alg", "")
+        insecure = alg.lower() == "none"
+        missing_exp = "exp" not in payload
+        weak = [c for c in ("iss", "aud") if c not in payload]
+        results.append({
+            "token": token,
+            "alg": alg,
+            "insecure_alg": insecure,
+            "missing_exp": missing_exp,
+            "weak_claims": weak,
+        })
+    return {"tokens": results}
+
+# Optional CLI for manual testing
+if __name__ == "__main__":  # pragma: no cover - simple manual usage
+    import sys, json as _json
+    hdrs = {"Authorization": sys.argv[1]} if len(sys.argv) > 1 else {}
+    body = sys.argv[2] if len(sys.argv) > 2 else ""
+    print(_json.dumps(jwt_audit(hdrs, body), indent=2))

--- a/tests/test_jwt_audit.py
+++ b/tests/test_jwt_audit.py
@@ -1,0 +1,58 @@
+import base64
+import json
+import hmac
+import hashlib
+import time
+import os
+import sys
+
+# ensure app module importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.tools.jwt_audit import jwt_audit
+
+
+def _b64(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+def make_jwt(payload, secret="secret", alg="HS256"):
+    header = {"typ": "JWT", "alg": alg}
+    header_b64 = _b64(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64(json.dumps(payload, separators=(",", ":")).encode())
+    if alg == "none":
+        signature = ""
+    else:
+        signing_input = f"{header_b64}.{payload_b64}".encode()
+        if alg == "HS256":
+            sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+        else:
+            raise NotImplementedError
+        signature = _b64(sig)
+    return f"{header_b64}.{payload_b64}.{signature}"
+
+def test_jwt_audit_flags_insecure_algorithm():
+    token = make_jwt({"sub": "1"}, alg="none")
+    res = jwt_audit(headers={"Authorization": f"Bearer {token}"})
+    t = res["tokens"][0]
+    assert t["insecure_alg"] is True
+
+def test_jwt_audit_flags_missing_expiration():
+    token = make_jwt({"sub": "1", "iss": "me", "aud": "you"})
+    res = jwt_audit(body=f"token={token}")
+    t = res["tokens"][0]
+    assert t["missing_exp"] is True and t["insecure_alg"] is False
+
+def test_jwt_audit_flags_weak_claims():
+    exp = int(time.time()) + 3600
+    token = make_jwt({"sub": "1", "exp": exp})
+    res = jwt_audit(headers={"X-JWT": token})
+    t = res["tokens"][0]
+    assert "iss" in t["weak_claims"] and "aud" in t["weak_claims"]
+
+def test_jwt_audit_secure_token_clean():
+    exp = int(time.time()) + 3600
+    payload = {"sub": "1", "exp": exp, "iss": "me", "aud": "you"}
+    token = make_jwt(payload)
+    res = jwt_audit(headers={"X-Token": token})
+    t = res["tokens"][0]
+    assert not t["insecure_alg"] and not t["missing_exp"] and not t["weak_claims"]


### PR DESCRIPTION
## Summary
- add jwt_audit tool to detect insecure JWT algorithms, missing expirations, and weak claims
- cover secure and insecure token scenarios with unit tests
- expose jwt_audit via main agent utilities

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy, missing requests)*
- `pytest tests/test_jwt_audit.py::test_jwt_audit_secure_token_clean -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68ae0240eab0832c8e4ca2a14f4eacb9