### PR TITLE
Add open redirect testing tool with localhost safeguards

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from tools.debug_finder import debug_finder
 from tools.crawler import crawl_site
 from tools.cors_audit import cors_audit
 from tools.methods_fuzzer import methods_fuzzer
+from tools.open_redirect import open_redirect
 load_dotenv()
 
 #load anthropic api key
@@ -25,7 +26,7 @@ app = FastAPI()
 
 agent = create_react_agent(
     model="anthropic:claude-3-7-sonnet-latest",  
-    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer],  
+    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, open_redirect],
     prompt="You are an experienced pentester. Perform a full pentest on the target. You have many tools available, use them to your advantage. When there are findings; Write a professional penetration test report based on provided findings. Structure it with: Executive Summary, Findings Overview, Detailed Technical Findings (with location, severity, description, impact, and proof of concept), Recommendations, and Conclusion. Add remediations if required for each finding. Ensure the writing is clear, concise, and formal, suitable for security professionals."  
 )
 

--- a/app/tools/open_redirect.py
+++ b/app/tools/open_redirect.py
@@ -1,0 +1,106 @@
+# tools/open_redirect.py
+"""
+Open redirect tester with localhost guardrails.
+
+What it does
+------------
+- Sends a list of common redirect parameters with a URL such as https://example.com.
+- Looks for HTTP redirect responses where the Location header points to that URL.
+- Hard-locked to localhost targets by default.
+
+Quick usage
+-----------
+from tools.open_redirect import open_redirect
+res = open_redirect(base_url="http://127.0.0.1:3000", path="/redirect")
+print(res)
+
+Agent usage (LangGraph create_react_agent)
+------------------------------------------
+Include open_redirect in tools=[...], then ask:
+{ "message": "Run open_redirect on /redirect" }
+
+Requirements
+------------
+- requests
+"""
+
+from typing import Dict, List, Any, Optional
+from urllib.parse import urlparse
+import requests
+
+LOCAL_NETLOCS = {"127.0.0.1", "localhost", "::1"}
+COMMON_PARAMS = ["next", "url", "redirect", "return", "r", "dest", "destination"]
+
+
+def _ensure_localhost(base_url: str) -> None:
+    parsed = urlparse(base_url if base_url.startswith(("http://", "https://")) else "http://" + base_url)
+    host = (parsed.hostname or "").lower()
+    if host not in LOCAL_NETLOCS:
+        raise PermissionError(
+            f"Refused: '{base_url}' is not a localhost target. "
+            "Add explicit allow-lists/consent checks for remote testing."
+        )
+
+
+def _normalize_base(base_url: str) -> str:
+    if not base_url.startswith(("http://", "https://")):
+        base_url = "http://" + base_url
+    return base_url.rstrip("/")
+
+
+def open_redirect(
+    base_url: str = "http://127.0.0.1:3000",
+    path: str = "/redirect",
+    params: Optional[List[str]] = None,
+    payload_url: str = "https://example.com",
+    timeout: int = 8,
+) -> Dict[str, Any]:
+    """
+    Attempt to detect open redirect vulnerabilities by injecting `payload_url` into
+    common redirect parameters on `path`.
+
+    Args:
+      base_url:    local base URL (default: http://127.0.0.1:3000)
+      path:        path to request (default: "/redirect")
+      params:      list of parameter names to try (defaults to COMMON_PARAMS)
+      payload_url: external URL to use for redirect testing
+      timeout:     request timeout in seconds
+
+    Returns:
+      dict with keys:
+        - tested: list of parameter names tested
+        - open_redirects: list of {param, status, location} for unvalidated redirects
+    """
+    base_url = _normalize_base(base_url)
+    _ensure_localhost(base_url)
+
+    print("Getting started with open redirect tester on target", base_url)
+
+    tested_params = params or COMMON_PARAMS
+    url = f"{base_url}{path if path.startswith('/') else '/' + path}"
+    sess = requests.Session()
+    findings: List[Dict[str, Any]] = []
+
+    parsed_base = urlparse(base_url)
+
+    for p in tested_params:
+        try:
+            r = sess.get(url, params={p: payload_url}, timeout=timeout, allow_redirects=False)
+        except requests.RequestException:
+            continue
+
+        loc = r.headers.get("Location")
+        if r.status_code in (301, 302, 303, 307, 308) and loc:
+            parsed_loc = urlparse(loc)
+            if parsed_loc.netloc and parsed_loc.netloc != parsed_base.netloc:
+                findings.append({"param": p, "status": r.status_code, "location": loc})
+
+    return {"tested": tested_params, "open_redirects": findings}
+
+
+# Optional CLI
+if __name__ == "__main__":
+    import json, sys
+    path = sys.argv[1] if len(sys.argv) > 1 else "/redirect"
+    res = open_redirect(path=path)
+    print(json.dumps(res, indent=2))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,12 @@ class TestHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(body.encode())
             return
+        if path == '/redirect':
+            target = up.parse_qs(parsed.query).get('next', [''])[0]
+            self.send_response(302)
+            self.send_header('Location', target)
+            self.end_headers()
+            return
         if path in ('/admin', '/admin/login', '/swagger'):
             self.send_response(200)
             self.send_header('Content-Type','text/html')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,6 +18,7 @@ from app.tools.crawler import crawl_site
 from app.tools.sqli_probe import sqli_probe
 from app.tools.xss_probe import xss_probe
 from app.tools.nmap_tool import nmap_scan
+from app.tools.open_redirect import open_redirect
 
 
 def test_http_fingerprint_success(http_server):
@@ -92,3 +93,13 @@ def test_nmap_scan_parses_output(monkeypatch):
 def test_nmap_scan_blocks_remote():
     with pytest.raises(PermissionError):
         nmap_scan("8.8.8.8")
+
+
+def test_open_redirect_detects(http_server):
+    res = open_redirect(base_url=http_server, path="/redirect", params=["next"])
+    assert any(f["param"] == "next" for f in res["open_redirects"])
+
+
+def test_open_redirect_blocks_remote():
+    with pytest.raises(PermissionError):
+        open_redirect(base_url="https://example.com")


### PR DESCRIPTION
## Summary
- add `open_redirect` tool to probe redirect parameters for unvalidated redirects
- guard against non-localhost targets and report external Location headers
- extend tests and local server to cover detection and safety
- integrate `open_redirect` into main agent tool list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae02443600832cbd1b44f84bb364d7