### PR TITLE
Add command injection tool and unit tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from tools.debug_finder import debug_finder
 from tools.crawler import crawl_site
 from tools.cors_audit import cors_audit
 from tools.methods_fuzzer import methods_fuzzer
+from tools.command_injection import command_injection
 load_dotenv()
 
 #load anthropic api key
@@ -25,7 +26,7 @@ app = FastAPI()
 
 agent = create_react_agent(
     model="anthropic:claude-3-7-sonnet-latest",  
-    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer],  
+    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, command_injection],
     prompt="You are an experienced pentester. Perform a full pentest on the target. You have many tools available, use them to your advantage. When there are findings; Write a professional penetration test report based on provided findings. Structure it with: Executive Summary, Findings Overview, Detailed Technical Findings (with location, severity, description, impact, and proof of concept), Recommendations, and Conclusion. Add remediations if required for each finding. Ensure the writing is clear, concise, and formal, suitable for security professionals."  
 )
 

--- a/app/tools/command_injection.py
+++ b/app/tools/command_injection.py
@@ -1,0 +1,138 @@
+# tools/command_injection.py
+"""
+Command injection probe with localhost guardrails.
+
+What it does
+------------
+- Sends one or more payloads to a chosen endpoint/parameter.
+- Works with GET (query param), POST JSON, or POST form.
+- Looks for common command execution output or errors in responses.
+- Hard-locked to localhost targets by default.
+
+Quick usage
+-----------
+from tools.command_injection import command_injection
+res = command_injection(base_url="http://127.0.0.1:3000", method="GET", path="/exec", param="cmd")
+print(res)
+
+Agent usage (LangGraph create_react_agent)
+------------------------------------------
+Include command_injection in tools=[...], then ask:
+{ "message": "Run command_injection on /exec with param cmd" }
+
+Requirements
+------------
+- requests
+"""
+
+from typing import Dict, List, Optional, Literal
+from urllib.parse import urlparse
+import requests
+
+LOCAL_NETLOCS = {"127.0.0.1", "localhost", "::1"}
+
+DEFAULT_PAYLOADS: List[str] = [
+    "id",
+    "whoami",
+    "uname -a",
+    "cat /etc/passwd",
+]
+
+OUTPUT_SIGNS = [
+    "uid=",
+    "gid=",
+    "root:x:",
+    "command not found",
+    "not recognized",
+    "sh:",
+]
+
+
+def _ensure_localhost(base_url: str) -> None:
+    parsed = urlparse(base_url if base_url.startswith(("http://", "https://")) else "http://" + base_url)
+    host = (parsed.hostname or "").lower()
+    if host not in LOCAL_NETLOCS:
+        raise PermissionError(
+            f"Refused: '{base_url}' is not a localhost target. "
+            "Add explicit allow-lists/consent checks if you intend remote testing.",
+        )
+
+
+def _normalize_base(base_url: str) -> str:
+    if not base_url.startswith(("http://", "https://")):
+        base_url = "http://" + base_url
+    return base_url.rstrip("/")
+
+
+def command_injection(
+    base_url: str = "http://127.0.0.1:3000",
+    method: Literal["GET", "POST_JSON", "POST_FORM"] = "GET",
+    path: str = "/",
+    param: str = "q",
+    payloads: Optional[List[str]] = None,
+    json_body: Optional[Dict] = None,
+    form_body: Optional[Dict] = None,
+    timeout: int = 8,
+) -> Dict[str, str]:
+    """
+    Attempt simple command injection via supplied payloads.
+
+    Args:
+      base_url: local base URL (default: http://127.0.0.1:3000)
+      method:   "GET", "POST_JSON", or "POST_FORM"
+      path:     request path (e.g., "/exec")
+      param:    parameter name to inject
+      payloads: list of payloads to try (default: DEFAULT_PAYLOADS)
+      json_body: base JSON for POST_JSON
+      form_body: base form data for POST_FORM
+      timeout:  per-request timeout (seconds)
+
+    Returns:
+      dict with keys: vulnerable (true/false), payload, evidence, snippet
+    """
+    base_url = _normalize_base(base_url)
+    _ensure_localhost(base_url)
+
+    url = f"{base_url}{path if path.startswith('/') else '/' + path}"
+    payloads = payloads or DEFAULT_PAYLOADS
+    session = requests.Session()
+
+    for p in payloads:
+        if method == "GET":
+            r = session.get(url, params={param: p}, timeout=timeout)
+        elif method == "POST_JSON":
+            body = dict(json_body or {})
+            body[param] = p
+            r = session.post(url, json=body, timeout=timeout, headers={"Content-Type": "application/json"})
+        elif method == "POST_FORM":
+            body = dict(form_body or {})
+            body[param] = p
+            r = session.post(url, data=body, timeout=timeout)
+        else:
+            raise ValueError("method must be one of: GET, POST_JSON, POST_FORM")
+
+        text = r.text[:4000]
+        evidence = next((sig for sig in OUTPUT_SIGNS if sig in text.lower()), "")
+        if evidence:
+            return {
+                "vulnerable": "true",
+                "payload": p,
+                "evidence": evidence,
+                "snippet": text[:200],
+                "status": str(r.status_code),
+            }
+
+    return {
+        "vulnerable": "false",
+        "payload": "",
+        "evidence": "",
+        "snippet": "",
+        "status": "",
+    }
+
+
+# Optional CLI
+if __name__ == "__main__":
+    import json, sys
+    m = sys.argv[1] if len(sys.argv) > 1 else "GET"
+    print(json.dumps(command_injection(method=m), indent=2))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import threading, json
 from http.server import BaseHTTPRequestHandler
 import socketserver
 import urllib.parse as up
+import subprocess
 
 class TestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -24,6 +25,14 @@ class TestHandler(BaseHTTPRequestHandler):
             self.send_header('Content-Type','text/html')
             self.end_headers()
             self.wfile.write(b'ok')
+            return
+        if path == '/exec':
+            cmd = up.parse_qs(parsed.query).get('cmd', [''])[0]
+            out = subprocess.getoutput(cmd)
+            self.send_response(200)
+            self.send_header('Content-Type','text/plain')
+            self.end_headers()
+            self.wfile.write(out.encode())
             return
         if path == '/page2':
             body = '<html><body><a href="/">home</a></body></html>'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,6 +18,7 @@ from app.tools.crawler import crawl_site
 from app.tools.sqli_probe import sqli_probe
 from app.tools.xss_probe import xss_probe
 from app.tools.nmap_tool import nmap_scan
+from app.tools.command_injection import command_injection
 
 
 def test_http_fingerprint_success(http_server):
@@ -66,6 +67,11 @@ def test_sqli_probe_detects_error(http_server):
 def test_xss_probe_detects_reflection(http_server):
     res = xss_probe(base_url=http_server, method="GET", path="/search", param="q")
     assert res["reflected"] == "true"
+
+
+def test_command_injection_detects_execution(http_server):
+    res = command_injection(base_url=http_server, method="GET", path="/exec", param="cmd", payloads=["id"])
+    assert res["vulnerable"] == "true"
 
 
 def test_nmap_scan_parses_output(monkeypatch):


### PR DESCRIPTION
## Summary
- add command injection probe with localhost guardrails
- extend test server with vulnerable `/exec` endpoint and add unit test
- register command injection tool with the agent so it can be invoked via chat

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0240dd7c832c981dcde2a954126e