### PR TITLE
docs: document new pentest tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ commands and receive pentest results.
   - `crawl_site` – lightweight crawler and form enumerator
   - `cors_audit` – inspect CORS responses and preflights
   - `methods_fuzzer` – probe enabled HTTP verbs
+  - `csrf_audit` – verify forms include anti-CSRF tokens
+  - `lfi_probe` – look for local file inclusion via path parameters
+  - `open_redirect` – detect unvalidated redirection to external sites
+  - `ssrf_probe` – attempt server-side request forgery payloads
+  - `jwt_audit` – analyze JSON Web Tokens for weak algorithms or claims
+  - `command_injection` – send shell metacharacters to discover unsanitized execution
 - All tools default to localhost targets for safety and require explicit
   configuration to scan remote hosts.
 
@@ -58,6 +64,25 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 - `GET /` returns a simple health message.
 - `POST /chat` with JSON `{ "message": "run headers_audit on http://127.0.0.1:3000" }`
   lets the agent execute tools and respond with results.
+
+## Tool Usage
+Invoke tools by name through the `/chat` endpoint. Replace the tool and target URL as needed:
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H 'Content-Type: application/json' \
+  -d '{ "message": "run csrf_audit on http://127.0.0.1:3000/login" }'
+```
+
+Examples for other recent additions:
+
+- `run lfi_probe on http://127.0.0.1:3000/read?file=note.txt`
+- `run open_redirect on http://127.0.0.1:3000/redirect?url=https://example.com`
+- `run ssrf_probe on http://127.0.0.1:3000/fetch?url=http://127.0.0.1`
+- `run jwt_audit on http://127.0.0.1:3000`
+- `run command_injection on http://127.0.0.1:3000/search?q=test`
+
+All tools default to localhost targets for safety.
 
 ## License
 This project is licensed under the terms of the MIT license.  See the `LICENSE`


### PR DESCRIPTION
## Summary
- document new tools in README
- explain how to invoke recent additions via /chat endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae01c8bd34832cbed4633ff487f672