### PR TITLE
Add data security and privacy tools

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,9 @@ from tools.jwt_audit import jwt_audit
 from tools.lfi_probe import lfi_probe
 from tools.csrf_audit import csrf_audit
 from tools.command_injection import command_injection
+from tools.sensitive_data_finder import sensitive_data_finder
+from tools.tls_ssl_audit import tls_ssl_audit
+from tools.cache_poisoning_probe import cache_poisoning_probe
 
 load_dotenv()
 
@@ -31,9 +34,9 @@ anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
 app = FastAPI()
 
 agent = create_react_agent(
-    model="anthropic:claude-3-7-sonnet-latest",  
+    model="anthropic:claude-3-7-sonnet-latest",
 
-    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, csrf_audit, command_injection, lfi_probe, jwt_audit, ssrf_probe, open_redirect],
+    tools=[ nmap_scan, http_fingerprint, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, csrf_audit, command_injection, lfi_probe, jwt_audit, ssrf_probe, open_redirect, sensitive_data_finder, tls_ssl_audit, cache_poisoning_probe],
 
     prompt="You are an experienced pentester. Perform a full pentest on the target. You have many tools available, use them to your advantage. When there are findings; Write a professional penetration test report based on provided findings. Structure it with: Executive Summary, Findings Overview, Detailed Technical Findings (with location, severity, description, impact, and proof of concept), Recommendations, and Conclusion. Add remediations if required for each finding. Ensure the writing is clear, concise, and formal, suitable for security professionals."  
 )

--- a/app/tools/cache_poisoning_probe.py
+++ b/app/tools/cache_poisoning_probe.py
@@ -1,0 +1,90 @@
+# tools/cache_poisoning_probe.py
+"""
+Cache poisoning probe with localhost guardrails.
+
+What it does
+------------
+- Sends crafted headers like X-Forwarded-Host and X-Original-URL to see if they are reflected.
+- Useful for detecting cache poisoning issues where upstream proxies honor these headers.
+- Hard-locked to localhost targets by default.
+
+Quick usage
+-----------
+from tools.cache_poisoning_probe import cache_poisoning_probe
+res = cache_poisoning_probe(base_url="http://127.0.0.1:3000", path="/")
+print(res)
+
+Agent usage (LangGraph create_react_agent)
+------------------------------------------
+Include cache_poisoning_probe in tools=[...], then ask:
+{ "message": "Run cache_poisoning_probe on /" }
+
+Requirements
+------------
+- requests
+"""
+
+from typing import Dict, Any, Optional
+from urllib.parse import urlparse
+import requests
+
+LOCAL_NETLOCS = {"127.0.0.1", "localhost", "::1"}
+DEFAULT_HEADERS = {"X-Forwarded-Host": "evil.com", "X-Original-URL": "/evil"}
+
+def _ensure_localhost(base_url: str) -> None:
+    parsed = urlparse(base_url if base_url.startswith(("http://", "https://")) else "http://" + base_url)
+    host = (parsed.hostname or "").lower()
+    if host not in LOCAL_NETLOCS:
+        raise PermissionError(
+            f"Refused: '{base_url}' is not a localhost target. "
+            "Add explicit allow-lists/consent checks for remote testing."
+        )
+
+def _normalize_base(base_url: str) -> str:
+    if not base_url.startswith(("http://", "https://")):
+        base_url = "http://" + base_url
+    return base_url.rstrip("/")
+
+def cache_poisoning_probe(
+    base_url: str = "http://127.0.0.1:3000",
+    path: str = "/",
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 8,
+) -> Dict[str, Any]:
+    """Send cache poisoning headers and look for reflection.
+
+    Args:
+      base_url: local base URL (default: http://127.0.0.1:3000)
+      path:     request path (default: "/")
+      headers:  extra headers to merge with defaults
+      timeout:  request timeout in seconds
+
+    Returns:
+      dict with keys: status, reflected
+    """
+    base_url = _normalize_base(base_url)
+    _ensure_localhost(base_url)
+
+    print("Getting started with cache poisoning probe on target", base_url)
+
+    url = f"{base_url}{path if path.startswith('/') else '/' + path}"
+    inj_headers = dict(DEFAULT_HEADERS)
+    if headers:
+        inj_headers.update(headers)
+    session = requests.Session()
+    r = session.get(url, headers=inj_headers, timeout=timeout)
+
+    reflected = []
+    body = r.text
+    for name, val in inj_headers.items():
+        if val in body or any(val in hv for hv in r.headers.values()):
+            reflected.append(name)
+
+    return {"status": str(r.status_code), "reflected": reflected}
+
+# Optional CLI
+if __name__ == "__main__":
+    import json, sys
+    path = sys.argv[1] if len(sys.argv) > 1 else "/"
+    res = cache_poisoning_probe(path=path)
+    print(json.dumps(res, indent=2))

--- a/app/tools/sensitive_data_finder.py
+++ b/app/tools/sensitive_data_finder.py
@@ -1,0 +1,93 @@
+# tools/sensitive_data_finder.py
+"""
+Sensitive data finder with localhost guardrails.
+
+What it does
+------------
+- Fetches a page and searches for common PII patterns such as emails, SSNs, and credit cards.
+- Hard-locked to localhost targets by default.
+
+Quick usage
+-----------
+from tools.sensitive_data_finder import sensitive_data_finder
+res = sensitive_data_finder(base_url="http://127.0.0.1:3000", path="/")
+print(res)
+
+Agent usage (LangGraph create_react_agent)
+------------------------------------------
+Include sensitive_data_finder in tools=[...], then ask:
+{ "message": "Run sensitive_data_finder on /" }
+
+Requirements
+------------
+- requests
+"""
+
+from typing import Dict, Any, Optional, List
+from urllib.parse import urlparse
+import re
+import requests
+
+LOCAL_NETLOCS = {"127.0.0.1", "localhost", "::1"}
+EMAIL_RE = re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+")
+SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+CC_RE = re.compile(r"\b(?:\d[ -]*?){13,16}\b")
+
+def _ensure_localhost(base_url: str) -> None:
+    parsed = urlparse(base_url if base_url.startswith(("http://", "https://")) else "http://" + base_url)
+    host = (parsed.hostname or "").lower()
+    if host not in LOCAL_NETLOCS:
+        raise PermissionError(
+            f"Refused: '{base_url}' is not a localhost target. "
+            "Add explicit allow-lists/consent checks for remote testing."
+        )
+
+def _normalize_base(base_url: str) -> str:
+    if not base_url.startswith(("http://", "https://")):
+        base_url = "http://" + base_url
+    return base_url.rstrip("/")
+
+def sensitive_data_finder(
+    base_url: str = "http://127.0.0.1:3000",
+    path: str = "/",
+    timeout: int = 8,
+) -> Dict[str, Any]:
+    """Fetch `path` and search for common PII patterns.
+
+    Args:
+      base_url: local base URL (default: http://127.0.0.1:3000)
+      path:     request path (default: "/")
+      timeout:  request timeout in seconds
+
+    Returns:
+      dict with keys: emails, ssns, credit_cards, any_pii
+    """
+    base_url = _normalize_base(base_url)
+    _ensure_localhost(base_url)
+
+    print("Getting started with sensitive data finder on target", base_url)
+
+    url = f"{base_url}{path if path.startswith('/') else '/' + path}"
+    session = requests.Session()
+    r = session.get(url, timeout=timeout)
+    text = r.text
+
+    emails = list({e.strip('.,;:') for e in EMAIL_RE.findall(text)})
+    ssns = list(set(SSN_RE.findall(text)))
+    credit_cards = list({c.strip(' .-') for c in CC_RE.findall(text)})
+
+    any_pii = bool(emails or ssns or credit_cards)
+
+    return {
+        "emails": emails,
+        "ssns": ssns,
+        "credit_cards": credit_cards,
+        "any_pii": "true" if any_pii else "false",
+    }
+
+# Optional CLI
+if __name__ == "__main__":
+    import json, sys
+    path = sys.argv[1] if len(sys.argv) > 1 else "/"
+    res = sensitive_data_finder(path=path)
+    print(json.dumps(res, indent=2))

--- a/app/tools/tls_ssl_audit.py
+++ b/app/tools/tls_ssl_audit.py
@@ -1,0 +1,86 @@
+# tools/tls_ssl_audit.py
+"""
+TLS/SSL configuration audit with localhost guardrails.
+
+What it does
+------------
+- Connects to an HTTPS service and inspects TLS version, cipher, and certificate expiry.
+- Flags usage of weak ciphers, expired certificates, or absence of TLS1.2+.
+- Hard-locked to localhost targets by default.
+
+Quick usage
+-----------
+from tools.tls_ssl_audit import tls_ssl_audit
+res = tls_ssl_audit(host="127.0.0.1", port=443)
+print(res)
+
+Agent usage (LangGraph create_react_agent)
+------------------------------------------
+Include tls_ssl_audit in tools=[...], then ask:
+{ "message": "Run tls_ssl_audit on 127.0.0.1" }
+
+Requirements
+------------
+- ssl, socket
+"""
+
+from typing import Dict
+from datetime import datetime
+import ssl
+import socket
+
+LOCAL_NETLOCS = {"127.0.0.1", "localhost", "::1"}
+WEAK_CIPHERS = {"RC4", "3DES", "DES", "MD5", "NULL"}
+
+def _ensure_localhost(host: str) -> None:
+    if host.lower() not in LOCAL_NETLOCS:
+        raise PermissionError(
+            f"Refused: '{host}' is not a localhost target. "
+            "Add explicit allow-lists/consent checks for remote testing."
+        )
+
+def tls_ssl_audit(host: str = "127.0.0.1", port: int = 443, timeout: int = 8) -> Dict[str, str]:
+    """Inspect TLS/SSL configuration for a given host/port.
+
+    Args:
+      host:    hostname (must be localhost)
+      port:    port number (default: 443)
+      timeout: connection timeout in seconds
+
+    Returns:
+      dict with keys: protocol, cipher, expired, tls12_plus, weak_cipher
+    """
+    _ensure_localhost(host)
+
+    print("Getting started with TLS/SSL audit on target", host)
+
+    ctx = ssl.create_default_context()
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        with ctx.wrap_socket(sock, server_hostname=host) as ssock:
+            protocol = ssock.version() or ""
+            cipher = ssock.cipher()[0] if ssock.cipher() else ""
+            cert = ssock.getpeercert() or {}
+            not_after = cert.get("notAfter")
+            expired = False
+            if not_after:
+                try:
+                    exp = datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
+                    expired = exp < datetime.utcnow()
+                except Exception:
+                    pass
+            tls12_plus = protocol in ("TLSv1.2", "TLSv1.3")
+            weak_cipher = any(w in cipher.upper() for w in WEAK_CIPHERS)
+
+    return {
+        "protocol": protocol,
+        "cipher": cipher,
+        "expired": "true" if expired else "false",
+        "tls12_plus": "true" if tls12_plus else "false",
+        "weak_cipher": "true" if weak_cipher else "false",
+    }
+
+# Optional CLI
+if __name__ == "__main__":
+    import json
+    res = tls_ssl_audit()
+    print(json.dumps(res, indent=2))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -23,6 +23,9 @@ from app.tools.ssrf_probe import ssrf_probe
 from app.tools.lfi_probe import lfi_probe
 from app.tools.csrf_audit import csrf_audit
 from app.tools.command_injection import command_injection
+from app.tools.sensitive_data_finder import sensitive_data_finder
+from app.tools.tls_ssl_audit import tls_ssl_audit
+from app.tools.cache_poisoning_probe import cache_poisoning_probe
 
 
 
@@ -152,3 +155,98 @@ def test_csrf_audit_detects_token(monkeypatch):
     assert res["forms"][0]["has_token"] == "true"
     assert res["forms"][0]["tokenless_status"] == "403"
     assert res["any_vulnerable"] == "false"
+
+
+def test_sensitive_data_finder_detects_pii(monkeypatch):
+    html = (
+        "Contact us at test@example.com. SSN: 123-45-6789. CC: 4111 1111 1111 1111"
+    )
+
+    class FakeResp:
+        def __init__(self, text):
+            self.text = text
+            self.status_code = 200
+
+    class FakeSession:
+        def get(self, url, timeout):
+            return FakeResp(html)
+
+    import requests
+
+    monkeypatch.setattr(requests, "Session", lambda: FakeSession())
+    res = sensitive_data_finder(base_url="http://127.0.0.1", path="/")
+    assert "test@example.com" in res["emails"]
+    assert "123-45-6789" in res["ssns"]
+    assert any("4111" in cc for cc in res["credit_cards"])
+
+
+def test_tls_ssl_audit_flags_weak(monkeypatch):
+    class FakeSSLSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def version(self):
+            return "TLSv1.1"
+
+        def cipher(self):
+            return ("RC4-SHA", "TLSv1/SSLv3", 128)
+
+        def getpeercert(self):
+            return {"notAfter": "Dec 31 23:59:59 2099 GMT"}
+
+    class FakeContext:
+        def wrap_socket(self, sock, server_hostname):
+            return FakeSSLSocket()
+
+    def fake_create_default_context():
+        return FakeContext()
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_create_connection(addr, timeout=None):
+        return FakeSocket()
+
+    import ssl, socket
+
+    monkeypatch.setattr(ssl, "create_default_context", fake_create_default_context)
+    monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+    res = tls_ssl_audit(host="127.0.0.1", port=443)
+    assert res["tls12_plus"] == "false"
+    assert res["weak_cipher"] == "true"
+    assert res["expired"] == "false"
+
+
+def test_tls_ssl_audit_blocks_remote():
+    with pytest.raises(PermissionError):
+        tls_ssl_audit(host="example.com")
+
+
+def test_cache_poisoning_probe_detects(monkeypatch):
+    class FakeResp:
+        def __init__(self):
+            self.status_code = 200
+            self.headers = {"Location": "http://evil.com/home"}
+            self.text = ""
+
+    class FakeSession:
+        def get(self, url, headers=None, timeout=8):
+            return FakeResp()
+
+    import requests
+
+    monkeypatch.setattr(requests, "Session", lambda: FakeSession())
+    res = cache_poisoning_probe(base_url="http://127.0.0.1", path="/")
+    assert "X-Forwarded-Host" in res["reflected"]
+
+
+def test_cache_poisoning_probe_blocks_remote():
+    with pytest.raises(PermissionError):
+        cache_poisoning_probe(base_url="https://example.com")


### PR DESCRIPTION
## Summary
- add sensitive data finder to scan responses for emails, SSNs, and credit cards
- implement TLS/SSL audit checking protocol, cipher strength and certificate expiry
- provide cache poisoning probe using X-Forwarded-Host and X-Original-URL headers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0949f4d0832cafb5702a12dd57d7