### PR TITLE
Add gobuster tool integration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ commands and receive pentest results.
   - `nmap_scan` – safe wrapper around `nmap` with allow-list controls
   - `http_fingerprint` – fetch HTTP headers and a title snippet
   - `dirbuster` – brute-force common directories and files
+  - `gobuster_scan` – wrapper for Gobuster directory/DNS enumeration with guardrails
   - `xss_probe` – send payloads to detect reflected XSS
   - `sqli_probe` – try classic SQL injection strings
   - `headers_audit` – check missing security headers and cookie flags

--- a/app/agent.py
+++ b/app/agent.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from tools.nmap_tool import nmap_scan
 from tools.http_fingerprint import http_fingerprint
 from tools.dirbuster import dirbuster
+from tools.gobuster_tool import gobuster_scan
 from tools.xss_probe import xss_probe
 from tools.sqli_probe import sqli_probe
 from tools.headers_audit import headers_audit
@@ -30,7 +31,7 @@ load_dotenv()
 
 agent = create_react_agent(
     model="anthropic:claude-3-5-haiku-latest",
-    tools=[ nmap_scan, http_fingerprint, tech_stack_detector, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, csrf_audit, command_injection, lfi_probe, jwt_audit, ssrf_probe, open_redirect, sensitive_data_finder, tls_ssl_audit, cache_poisoning_probe, weak_password_auditor, twofa_bypass_tester, session_fixation_probe ],
+    tools=[ nmap_scan, http_fingerprint, tech_stack_detector, dirbuster, gobuster_scan, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, csrf_audit, command_injection, lfi_probe, jwt_audit, ssrf_probe, open_redirect, sensitive_data_finder, tls_ssl_audit, cache_poisoning_probe, weak_password_auditor, twofa_bypass_tester, session_fixation_probe ],
     prompt="You are an experienced pentester. Perform a scan or pentest on the target. You have many tools available, use them to your advantage. When there are findings; Write a professional penetration test report based on provided findings. Structure it with: Executive Summary, Findings Overview, Detailed Technical Findings (with location, severity, description, impact, and proof of concept), Recommendations, and Conclusion. Add remediations if required for each finding. Ensure the writing is clear, concise, and formal, suitable for security professionals."  
 )
 
@@ -54,7 +55,7 @@ research_agent = create_react_agent(
 
 cybersecurity_agent = create_react_agent(
     model="anthropic:claude-3-5-haiku-latest",
-    tools=[ nmap_scan, http_fingerprint, tech_stack_detector, dirbuster, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, csrf_audit, command_injection, lfi_probe, jwt_audit, ssrf_probe, open_redirect, sensitive_data_finder, tls_ssl_audit, cache_poisoning_probe, weak_password_auditor, twofa_bypass_tester, session_fixation_probe ],
+    tools=[ nmap_scan, http_fingerprint, tech_stack_detector, dirbuster, gobuster_scan, xss_probe, sqli_probe, headers_audit, debug_finder, crawl_site, cors_audit, methods_fuzzer, csrf_audit, command_injection, lfi_probe, jwt_audit, ssrf_probe, open_redirect, sensitive_data_finder, tls_ssl_audit, cache_poisoning_probe, weak_password_auditor, twofa_bypass_tester, session_fixation_probe ],
     prompt=(
         "You are a cybersecurity agent.\n\n"
         "INSTRUCTIONS:\n"

--- a/app/tools/gobuster_tool.py
+++ b/app/tools/gobuster_tool.py
@@ -1,0 +1,239 @@
+# tools/gobuster_tool.py
+"""Gobuster wrapper with localhost-first guardrails.
+
+This module provides a thin, safety-conscious wrapper around the
+[`gobuster`](https://github.com/OJ/gobuster) CLI.  It is designed to be used
+by the PentestAIAgent so the agent can enumerate directories (and optionally
+DNS subdomains) in a way that mimics the real utility while remaining safe for
+local testing environments.
+
+Highlights
+---------
+- Defaults to the `dir` mode and only permits localhost targets unless the
+  user has explicitly opted-in to remote testing via environment variables.
+- Accepts in-memory wordlists (helpful for automated tests) or file paths.
+- Normalises and sanitises options before invoking the external binary.
+- Parses Gobuster's textual output into structured results that are friendly
+  for LLM consumption.
+
+Environment variables
+---------------------
+- ``GOBUSTER_PATH`` – optional path to the gobuster binary (default: ``gobuster``).
+- ``ALLOW_REMOTE_PENTEST`` and ``PENTEST_ALLOWLIST`` – honour the same flag/
+  allow-list pattern as other tools in the project when remote hosts must be
+  scanned.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urlparse
+
+# Compact defaults to keep automated tests quick while still being realistic.
+DEFAULT_DIR_WORDS: Tuple[str, ...] = (
+    "",  # allow testing of the base URL
+    "admin",
+    "login",
+    "dashboard",
+    "api",
+    "uploads",
+    "static",
+    "images",
+    "config",
+)
+
+DEFAULT_DNS_WORDS: Tuple[str, ...] = (
+    "www",
+    "api",
+    "admin",
+    "dev",
+    "test",
+)
+
+LOCAL_NETLOCS = {"127.0.0.1", "localhost", "::1"}
+
+
+def _remote_testing_allowed(host: str) -> bool:
+    """Return True if remote enumeration is permitted for ``host``."""
+
+    allow_flag = os.getenv("ALLOW_REMOTE_PENTEST", "")
+    allowlist = {
+        h.strip().lower()
+        for h in os.getenv("PENTEST_ALLOWLIST", "").split(",")
+        if h.strip()
+    }
+    host = host.lower()
+    return allow_flag == "I_ACCEPT_RESPONSIBILITY" and host in allowlist
+
+
+def _normalise_target(mode: str, target: str) -> str:
+    """Normalise the target based on the requested Gobuster mode.
+
+    For ``dir`` mode we normalise to a URL string, enforcing localhost (unless
+    explicitly allowed).  For ``dns`` mode we operate on raw hostnames.
+    """
+
+    if mode == "dir":
+        if not target.startswith(("http://", "https://")):
+            target = "http://" + target
+        parsed = urlparse(target)
+        host = (parsed.hostname or "").lower()
+        if host not in LOCAL_NETLOCS and not _remote_testing_allowed(host):
+            raise PermissionError(
+                "Refused: Gobuster directory scans are limited to localhost. "
+                "Set ALLOW_REMOTE_PENTEST and include the host in "
+                "PENTEST_ALLOWLIST to override."
+            )
+        return target.rstrip("/") or target
+
+    if mode == "dns":
+        host = target.strip().lower()
+        if not host:
+            raise ValueError("DNS mode requires a hostname (e.g. 'example.com').")
+        if host not in LOCAL_NETLOCS and not _remote_testing_allowed(host):
+            raise PermissionError(
+                "Refused: Gobuster DNS scans are limited to localhost-style hosts. "
+                "Set ALLOW_REMOTE_PENTEST and include the host in "
+                "PENTEST_ALLOWLIST to override."
+            )
+        return host
+
+    raise ValueError(f"Unsupported mode '{mode}'. Use 'dir' or 'dns'.")
+
+
+def _prepare_wordlist(words: Optional[Iterable[str]], defaults: Tuple[str, ...]) -> Tuple[str, Optional[str]]:
+    """Return (path, cleanup_path) for Gobuster's ``--wordlist`` option."""
+
+    if isinstance(words, str):
+        return words, None
+
+    items = list(dict.fromkeys(words or defaults))  # preserve order, remove duplicates
+    tmp = tempfile.NamedTemporaryFile("w", delete=False)
+    try:
+        tmp.write("\n".join(items))
+        if items and items[-1] != "":
+            tmp.write("\n")
+        tmp.flush()
+    finally:
+        tmp.close()
+    return tmp.name, tmp.name
+
+
+LINE_RE = re.compile(
+    r"^(?P<entry>/[^\s]*)\s*"
+    r"\(Status:\s*(?P<status>\d{3})\)"
+    r"(?:\s*\[Size:\s*(?P<size>\d+)\])?"
+    r"(?:\s*\[[\-=]{1,2}>\s*(?P<redirect>[^\]]+)\])?",
+    re.IGNORECASE,
+)
+
+
+def _parse_gobuster_output(stdout: str) -> List[Dict[str, Any]]:
+    """Extract hit entries from gobuster's stdout."""
+
+    hits: List[Dict[str, Any]] = []
+    for line in stdout.splitlines():
+        match = LINE_RE.search(line.strip())
+        if not match:
+            continue
+        data: Dict[str, Any] = {
+            "path": match.group("entry"),
+            "status": int(match.group("status")),
+        }
+        if match.group("size"):
+            data["size"] = int(match.group("size"))
+        if match.group("redirect"):
+            data["redirect"] = match.group("redirect").strip()
+        hits.append(data)
+    return hits
+
+
+def gobuster_scan(
+    target: str,
+    mode: str = "dir",
+    wordlist: Optional[Iterable[str]] = None,
+    extensions: Optional[Iterable[str]] = None,
+    timeout: int = 60,
+    binary: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run Gobuster with sensible defaults and return a structured summary."""
+
+    mode = mode.lower()
+    normalised_target = _normalise_target(mode, target)
+
+    gobuster_bin = binary or os.getenv("GOBUSTER_PATH", "gobuster")
+    if not gobuster_bin:
+        raise ValueError("Gobuster binary path cannot be empty.")
+
+    cleanup_path: Optional[str] = None
+    try:
+        defaults = DEFAULT_DIR_WORDS if mode == "dir" else DEFAULT_DNS_WORDS
+        wordlist_path, cleanup_path = _prepare_wordlist(wordlist, defaults)
+
+        args: List[str] = [gobuster_bin, mode]
+        if mode == "dir":
+            args += ["--url", normalised_target]
+            clean_exts = []
+            if extensions:
+                for ext in extensions:
+                    if not ext:
+                        continue
+                    ext = ext.strip().lstrip(".")
+                    if ext and "/" not in ext and "\\" not in ext:
+                        clean_exts.append(ext)
+            if clean_exts:
+                args += ["-x", ",".join(clean_exts)]
+        elif mode == "dns":
+            args += ["-d", normalised_target]
+
+        args += ["--wordlist", wordlist_path, "--no-color"]
+
+        try:
+            proc = subprocess.run(
+                args,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Gobuster binary '{gobuster_bin}' not found. Install gobuster or set GOBUSTER_PATH."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("Gobuster scan timed out.") from exc
+
+        if proc.returncode not in (0, 1):
+            stderr = (proc.stderr or "").strip()
+            raise RuntimeError(
+                f"Gobuster failed (code {proc.returncode}). {stderr[:400] if stderr else 'No stderr output.'}"
+            )
+
+        hits = _parse_gobuster_output(proc.stdout or "")
+
+        summary = {
+            "target": normalised_target,
+            "mode": mode,
+            "command": " ".join(shlex.quote(part) for part in args),
+            "return_code": proc.returncode,
+            "hits": hits,
+            "stderr": (proc.stderr or "").strip() or None,
+            "raw_output": (proc.stdout or "").strip()[:4000] or None,
+            "summary": f"gobuster {mode} -> hits={len(hits)} return_code={proc.returncode}",
+        }
+        return summary
+    finally:
+        if cleanup_path:
+            try:
+                os.unlink(cleanup_path)
+            except OSError:
+                pass
+
+
+__all__ = ["gobuster_scan"]
+

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,6 +10,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.tools.http_fingerprint import http_fingerprint
 from app.tools.dirbuster import dirbuster
+from app.tools.gobuster_tool import gobuster_scan
 from app.tools.headers_audit import headers_audit
 from app.tools.debug_finder import debug_finder
 from app.tools.cors_audit import cors_audit
@@ -38,6 +39,33 @@ def test_http_fingerprint_success(http_server):
 def test_dirbuster_hits_admin(http_server):
     res = dirbuster(base_url=f"{http_server}/")
     assert any(h["path"] == "admin" for h in res["hits"])
+
+
+def test_gobuster_dir_parses_hits(monkeypatch):
+    sample_output = """
+    =====================================================
+    Gobuster v3
+    =====================================================
+    /admin (Status: 200) [Size: 123]
+    /images (Status: 301) [-> /images/]
+    Progress: 10 / 10 (100.00%)
+    =====================================================
+    """
+
+    def fake_run(args, check, capture_output, text, timeout):
+        assert args[0].endswith("gobuster") or args[0] == "gobuster"
+        assert "--url" in args
+        return SimpleNamespace(stdout=sample_output, stderr="", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    res = gobuster_scan("http://127.0.0.1:8080", wordlist=["admin", "images"])
+    assert any(hit["path"] == "/admin" for hit in res["hits"])
+    assert any(hit.get("redirect") == "/images/" for hit in res["hits"])
+
+
+def test_gobuster_blocks_remote():
+    with pytest.raises(PermissionError):
+        gobuster_scan("http://example.com")
 
 
 def test_headers_audit_missing_csp(http_server):


### PR DESCRIPTION
## Summary
- add a safety-conscious Gobuster wrapper that normalises targets, prepares wordlists, and parses output
- expose the new gobuster_scan tool to both agent configurations and document it in the README
- cover the tool with pytest cases for parsing success and remote-target guardrails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d6d6e440832cabcd8689d22ff528